### PR TITLE
Allow implicit conversion of dimensionless quantities to NumericalType

### DIFF
--- a/units.hpp
+++ b/units.hpp
@@ -224,6 +224,9 @@ namespace unitscxx
 			typename numerator::value_type>::value,
 			"quantity with incompatible unit systems");
 
+		template<typename NT, typename N, typename D>
+		friend class quantity;
+
 		constexpr quantity() : rawValue{} {};
 		constexpr quantity(const quantity&) = default;
 		constexpr quantity(quantity&&) = default;

--- a/units.hpp
+++ b/units.hpp
@@ -349,6 +349,11 @@ namespace unitscxx
 
 			return result_quantity(raw() / that.raw());
 		}
+
+		template<typename N = Numerator, typename D = Denominator,
+			typename = typename std::enable_if<N::size == 0 && D::size == 0>::type>
+		constexpr operator NumericType()
+		{ return raw(); }
 	};
 
 	template<typename MulType, typename NT, typename N, typename D>

--- a/units.hpp
+++ b/units.hpp
@@ -224,18 +224,16 @@ namespace unitscxx
 			typename numerator::value_type>::value,
 			"quantity with incompatible unit systems");
 
-		constexpr quantity() = default;
+		constexpr quantity() : rawValue{} {};
 		constexpr quantity(const quantity&) = default;
 		constexpr quantity(quantity&&) = default;
 		quantity& operator=(const quantity&) = default;
 		quantity& operator=(quantity&&) = default;
 
-		explicit constexpr quantity(NumericType rawValue)
-		: rawValue(rawValue)
+		explicit constexpr quantity(NumericType val)
+			: rawValue(val)
 		{
 		}
-
-		constexpr NumericType raw() const { return rawValue; }
 
 		quantity& operator+=(quantity that)
 		{
@@ -249,22 +247,22 @@ namespace unitscxx
 
 		constexpr quantity operator+(quantity that) const
 		{
-			return quantity(raw() + that.raw());
+			return quantity(rawValue + that.rawValue);
 		}
 
 		constexpr quantity operator-(quantity that) const
 		{
-			return quantity(raw() - that.raw());
+			return quantity(rawValue - that.rawValue);
 		}
 
 		constexpr quantity operator+() const
 		{
-			return quantity(+raw());
+			return quantity(+rawValue);
 		}
 
 		constexpr quantity operator-() const
 		{
-			return quantity(-raw());
+			return quantity(-rawValue);
 		}
 
 		quantity& operator*=(NumericType that)
@@ -281,7 +279,7 @@ namespace unitscxx
 
 		constexpr quantity operator*(NumericType that) const
 		{
-			return quantity(raw() * that);
+			return quantity(rawValue * that);
 		}
 
 		template<typename NT, typename N, typename D>
@@ -307,16 +305,16 @@ namespace unitscxx
 				result_denominator;
 
 			typedef quantity<
-				decltype(raw() * that.raw()),
+				decltype(rawValue * that.rawValue),
 				result_numerator,
 				result_denominator> result_quantity;
 
-			return result_quantity(raw() * that.raw());
+			return result_quantity(rawValue * that.rawValue);
 		}
 
 		constexpr quantity operator/(NumericType that) const
 		{
-			return quantity(raw() / that);
+			return quantity(rawValue / that);
 		}
 
 		template<typename NT, typename N, typename D>
@@ -343,17 +341,19 @@ namespace unitscxx
 				result_denominator;
 
 			typedef quantity<
-				decltype(raw() / that.raw()),
+				decltype(rawValue / that.rawValue),
 				result_numerator,
 				result_denominator> result_quantity;
 
-			return result_quantity(raw() / that.raw());
+			return result_quantity(rawValue / that.rawValue);
 		}
 
-		template<typename N = Numerator, typename D = Denominator,
-			typename = typename std::enable_if<N::size == 0 && D::size == 0>::type>
+		template<typename N = Numerator, typename D = Denominator, typename
+			= typename std::enable_if<N::size == 0 && D::size == 0>::type>
 		constexpr operator NumericType()
-		{ return raw(); }
+		{
+			return rawValue;
+		}
 	};
 
 	template<typename MulType, typename NT, typename N, typename D>


### PR DESCRIPTION
Okay, it's actually NumericType, without the al, but now I've already created the commit...
