### PR TITLE
Add some more operator overloads

### DIFF
--- a/units.hpp
+++ b/units.hpp
@@ -493,6 +493,34 @@ namespace unitscxx
 		return quantity<ResNT, N, D>(lhs - static_cast<NT>(rhs));
 	}
 
+	template<typename RNT, typename NT, typename N, typename D, typename =
+		std::enable_if_t<std::is_arithmetic<RNT>::value && N::size == 0 && D::size == 0>>
+	constexpr auto operator+=(RNT lhs, quantity<NT, N, D> rhs)
+	{
+		lhs += static_cast<NT>(rhs);
+	}
+
+	template<typename RNT, typename NT, typename N, typename D, typename =
+		std::enable_if_t<std::is_arithmetic<RNT>::value && N::size == 0 && D::size == 0>>
+	constexpr auto operator-=(RNT lhs, quantity<NT, N, D> rhs)
+	{
+		lhs -= static_cast<NT>(rhs);
+	}
+
+	template<typename RNT, typename NT, typename N, typename D, typename =
+		std::enable_if_t<std::is_arithmetic<RNT>::value && N::size == 0 && D::size == 0>>
+	constexpr auto operator*=(RNT lhs, quantity<NT, N, D> rhs)
+	{
+		lhs *= static_cast<NT>(rhs);
+	}
+
+	template<typename RNT, typename NT, typename N, typename D, typename =
+		std::enable_if_t<std::is_arithmetic<RNT>::value && N::size == 0 && D::size == 0>>
+	constexpr auto operator/=(RNT lhs, quantity<NT, N, D> rhs)
+	{
+		lhs /= static_cast<NT>(rhs);
+	}
+
 	template<typename NumericType, typename UnitType, UnitType... U>
 	using unit_base = quantity<NumericType,
 		detail::sequence<UnitType, U...>,


### PR DESCRIPTION
This is useful when interfacing with code that doesn't use unit types.

Previously, one had to write:

```c++
my_double += static_cast<double>(some_length / m);
```

With this change, the static_cast can be dropped:

```c++
my_double += some_length / m;
```